### PR TITLE
Complete todos

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ into Google Calendar events.
 | Field      | Type                                   | Required/Optional | Description                                        |
 | ---------- | -------------------------------------- | ----------------- | -------------------------------------------------- |
 | start-date | string (`YYYY-MM-DD` format preferred) | Required          | Date of the Sunday which starts the scheduled week |
-| schedule   | array of `ScheduleData` objects        | Required          | Cooking event information                          |
+| schedule   | array of `ScheduleItem` objects        | Required          | Cooking event information                          |
 
-where a `ScheduleData` object consists of
+where a `ScheduleItem` object consists of
 
 | Field | Type   | Required/Optional | Description                                   | Allowed Values                    |
 | ----- | ------ | ----------------- | --------------------------------------------- | --------------------------------- |

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import { ScheduleRequestBody } from '@/interfaces';
 import { Schedule } from '@/models';
 import { GoogleCalendarService } from '@/services';
 
@@ -7,11 +8,10 @@ const app = express();
 app.use(express.json()); // parsing of JSON request bodies
 app.post('/schedule', async ({ body }, res) => {
   try {
-    // TODO typing on request body
-    const { schedule: scheduleData, 'start-date': start } = body;
-    const schedule = Schedule.fromScheduleData(scheduleData, start);
+    const { schedule: scheduleItems, 'start-date': start } = body as ScheduleRequestBody;
+    const { events } = Schedule.fromScheduleItems(scheduleItems, start);
     try {
-      await GoogleCalendarService.addEvents(schedule.events);
+      await GoogleCalendarService.addEvents(events);
       res.sendStatus(201);
     } catch (err) {
       res.sendStatus(502);

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,0 +1,2 @@
+export * from './schedule-item';
+export * from './schedule-request-body';

--- a/src/interfaces/schedule-item.ts
+++ b/src/interfaces/schedule-item.ts
@@ -1,6 +1,9 @@
 /** Interface for schedule entries submitted to the chef-cal-integration API. */
 export interface ScheduleItem {
+  /** Type of meal the chef will cook */
   type: 'main' | 'side';
+  /** Name of person cooking */
   chef: string;
+  /** Day of the week on which cooking event falls (three-letter abbreviation) */
   day: string;
 }

--- a/src/interfaces/schedule-item.ts
+++ b/src/interfaces/schedule-item.ts
@@ -1,0 +1,6 @@
+/** Interface for schedule entries submitted to the chef-cal-integration API. */
+export interface ScheduleItem {
+  type: 'main' | 'side';
+  chef: string;
+  day: string;
+}

--- a/src/interfaces/schedule-request-body.ts
+++ b/src/interfaces/schedule-request-body.ts
@@ -2,6 +2,8 @@ import { ScheduleItem } from '.';
 
 /** Shape of body expected on requests to /schedule */
 export interface ScheduleRequestBody {
+  /** Date of Sunday which starts the scheduled week */
   'start-date': string;
+  /** Cooking event information */
   schedule: ScheduleItem[];
 }

--- a/src/interfaces/schedule-request-body.ts
+++ b/src/interfaces/schedule-request-body.ts
@@ -1,0 +1,7 @@
+import { ScheduleItem } from '.';
+
+/** Shape of body expected on requests to /schedule */
+export interface ScheduleRequestBody {
+  'start-date': string;
+  schedule: ScheduleItem[];
+}

--- a/src/models/__tests__/event-date-time.test.ts
+++ b/src/models/__tests__/event-date-time.test.ts
@@ -3,7 +3,7 @@ import { EventDateTime } from '..';
 
 describe('model: EventDateTime', () => {
   describe('constructor', () => {
-    it('formats the date in the format Google expects', () => {
+    it('formats date as Google expects', () => {
       const { date } = new EventDateTime(moment().toDate());
       expect(moment(date, EventDateTime.dateFormat).isValid()).toBe(true);
     });

--- a/src/models/__tests__/event.test.ts
+++ b/src/models/__tests__/event.test.ts
@@ -2,8 +2,8 @@ import moment from 'moment';
 import { Event, EventDateTime } from '..';
 
 describe('model: Event', () => {
-  const date = moment().toDate();
   const summary = 'my event';
+  const date = moment().toDate();
   const event = new Event({ summary, date });
 
   describe('constructor', () => {
@@ -17,6 +17,7 @@ describe('model: Event', () => {
     });
 
     it('sets the start date equal to the end date', () => {
+      expect(event.start.date).toBe(moment(date).format(EventDateTime.dateFormat));
       expect(event.start).toBe(event.end);
     });
   });

--- a/src/models/__tests__/schedule.test.ts
+++ b/src/models/__tests__/schedule.test.ts
@@ -1,8 +1,8 @@
 import moment from 'moment';
+import { ScheduleItem } from '@/interfaces';
 import { Schedule } from '..';
-import { ScheduleData } from '../schedule';
 
-const scheduleData: ScheduleData = {
+const scheduleItem: ScheduleItem = {
   type: 'Main',
   chef: 'Lloyd',
   day: 'Sun',
@@ -10,17 +10,17 @@ const scheduleData: ScheduleData = {
 
 describe('model: Schedule', () => {
   describe('methods', () => {
-    describe('static fromScheduleData', () => {
+    describe('static fromScheduleItems', () => {
       const date = moment()
         .day(0)
         .format('YYYY-MM-DD');
-      const schedule = Schedule.fromScheduleData([scheduleData], date);
+      const schedule = Schedule.fromScheduleItems([scheduleItem], date);
 
       it('returns a new Schedule instance', () => {
         expect(schedule).toBeInstanceOf(Schedule);
       });
 
-      it('sets the schedule data', () => {
+      it('sets the schedule', () => {
         const [event] = schedule.events;
         expect(schedule.events).toHaveLength(1);
         expect(event.summary).toContain('Main');

--- a/src/models/__tests__/tsconfig.json
+++ b/src/models/__tests__/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["../../node_modules"]
+}

--- a/src/models/schedule.ts
+++ b/src/models/schedule.ts
@@ -1,13 +1,7 @@
 import moment from 'moment';
+import { ScheduleItem } from '@/interfaces';
 import { Event } from '.';
 import capitalize from '@/utils/capitalize';
-
-/** Interface for schedule entries submitted to the chef-cal-integration API. */
-export interface ScheduleData {
-  type: string;
-  chef: string;
-  day: string;
-}
 
 /** Maps day of the week to 0–4 numeric value */
 enum days {
@@ -23,9 +17,9 @@ export default class Schedule {
   constructor(public events: Event[]) {}
 
   /** Construct a new Schedule from data conforming to the chef-cal-integration external API */
-  static fromScheduleData(scheduleData: ScheduleData[], start: string): Schedule {
+  static fromScheduleItems(scheduleItems: ScheduleItem[], start: string): Schedule {
     return new Schedule(
-      scheduleData.map(({ type, chef, day }) => {
+      scheduleItems.map(({ type, chef, day }) => {
         const summary = `${capitalize(type)} — ${capitalize(chef)}`;
         const date = moment(start, 'YYYY-MM-DD');
         date.add(days[day.toUpperCase()], 'days');

--- a/src/services/__tests__/google-calendar.test.ts
+++ b/src/services/__tests__/google-calendar.test.ts
@@ -1,18 +1,22 @@
+import { google } from 'googleapis';
 import { GoogleCalendarService } from '..';
 import { Event } from '@/models';
 
-const mockInsert = jest.fn();
-jest.mock('googleapis', () => ({
-  google: {
-    auth: {
-      GoogleAuth: class {
-        getClient = () => ({ email: 'my service email' });
+jest.mock('googleapis', () => {
+  const mockInsert = jest.fn();
+  return {
+    google: {
+      auth: {
+        GoogleAuth: class {
+          getClient = () => ({ email: 'my service email' });
+        },
       },
+      calendar: () => ({ events: { insert: mockInsert } }),
     },
-    calendar: () => ({ events: { insert: mockInsert } }),
-  },
-}));
+  };
+});
 
+const mockInsert = google.calendar('v3').events.insert as jest.Mock;
 interface MockInsertArg {
   auth: { email: string };
   calendarId: string;

--- a/src/services/google-calendar.ts
+++ b/src/services/google-calendar.ts
@@ -10,6 +10,9 @@ export default class GoogleCalendarService {
     scopes: ['https://www.googleapis.com/auth/calendar'],
   });
 
+  /** Events API for Google Calendar */
+  private static readonly calendarEvents = google.calendar('v3').events;
+
   /** Obtain a JWT to authenticate Google Calendar requests */
   private static getJWT() {
     return this.googleAuthInstance.getClient() as Promise<JWT>;
@@ -23,9 +26,8 @@ export default class GoogleCalendarService {
    */
   static async addEvents(events: Event[], calendarId = 'primary') {
     const auth = await this.getJWT();
-    const { events: calendar } = google.calendar('v3');
     const requests = events.map(event =>
-      calendar.insert({
+      this.calendarEvents.insert({
         auth,
         calendarId,
         requestBody: event,

--- a/src/utils/capitalize.ts
+++ b/src/utils/capitalize.ts
@@ -3,6 +3,6 @@
  *
  * @param {string} - The string to capitalize
  */
-export default function capitalize([char, ...string]: string): string {
+export default function capitalize([char, ...string]: string) {
   return `${char.toUpperCase()}${string.join('').toLowerCase()}`;
 }


### PR DESCRIPTION
Rename `ScheduleData` --> `ScheduleItems`. Most importantly, apply typing to request body, and extract `google.calendar('v3').events` into a static property on `GoogleAuthService`, so it isn't assigned on each call to `addEvents`.