### PR TITLE
Automatically clear mock functions before each test

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
+    "clearMocks": true,
     "moduleNameMapper": {
       "@/(.*)$": "<rootDir>/src/$1"
     }

--- a/src/__tests__/app.test.ts
+++ b/src/__tests__/app.test.ts
@@ -54,11 +54,6 @@ describe('express server', () => {
       describe('response status', () => {
         let response: request.Response;
 
-        beforeEach(() => {
-          spyFromScheduleItems.mockClear();
-          spyAddEvents.mockClear();
-        });
-
         it('responds with 400 "bad request" status to invalid requests', async () => {
           response = await request(app)
             .post('/schedule')

--- a/src/__tests__/app.test.ts
+++ b/src/__tests__/app.test.ts
@@ -23,9 +23,7 @@ describe('express server', () => {
   describe('endpoints', () => {
     describe('post /schedule', () => {
       describe('operations', () => {
-        beforeAll(async () => {
-          spyFromScheduleItems.mockClear();
-          spyAddEvents.mockClear();
+        beforeEach(async () => {
           await request(app)
             .post('/schedule')
             .send(requestBody);

--- a/src/services/__tests__/google-calendar.test.ts
+++ b/src/services/__tests__/google-calendar.test.ts
@@ -32,7 +32,6 @@ describe('service: GoogleCalendarService', () => {
       ];
 
       beforeEach(async () => {
-        jest.clearAllMocks();
         await GoogleCalendarService.addEvents(events);
       });
 


### PR DESCRIPTION
Enable the `clearMocks` setting on the Jest configuration to automatically clear all mock functions before each test. Remove all unnecessary manual mock clears. Read [here](https://jestjs.io/docs/en/configuration.html#clearmocks-boolean) for more information.