### PR TITLE
Write chef model & refactor EventDateTime

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,6 +25,7 @@
     "lines-between-class-members": "off",
     "no-empty": "off",
     "no-empty-function": "off",
+    "no-plusplus": "off",
     "no-return-await": "off",
     "no-underscore-dangle": "off",
     "no-unused-vars": "off",

--- a/.eslintrc
+++ b/.eslintrc
@@ -29,6 +29,7 @@
     "no-return-await": "off",
     "no-underscore-dangle": "off",
     "no-unused-vars": "off",
-    "no-useless-constructor": "off"
+    "no-useless-constructor": "off",
+    "object-curly-newline": ["error", { "multiline": true }]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ coverage
 dist
 docs
 node_modules
+scripts
 credentials.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,11 +4,13 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Launch via NPM",
-      "runtimeExecutable": "npm",
+      "name": "Run node script",
+      "runtimeExecutable": "node",
       "runtimeArgs": [
-        "run",
-        "start:watch"
+        "--inspect",
+        "-r",
+        "ts-node/register",
+        "${input:path}"
       ],
       "port": 9229,
       "skipFiles": [
@@ -25,4 +27,12 @@
       ]
     }
   ],
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "path",
+      "description": "Path to node script to run",
+      "default": "src/server.ts"
+    }
+  ]
 }

--- a/src/@types/nodejs.d.ts
+++ b/src/@types/nodejs.d.ts
@@ -6,6 +6,8 @@ declare namespace NodeJS {
     readonly AUTH_TOKEN: string;
     /** Phone number from which chef-cal-integration SMS messages will be sent */
     readonly HOST_NUMBER: string;
+    /** Array of people used until a DB solution becomes necessary */
+    readonly PEOPLE: string;
     /** Credentials to authenticate as a Google service account */
     readonly CREDENTIALS: string;
     /** Current runtime environment */

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,2 +1,3 @@
+export * from './person';
 export * from './schedule-item';
 export * from './schedule-request-body';

--- a/src/interfaces/person.ts
+++ b/src/interfaces/person.ts
@@ -1,0 +1,6 @@
+export interface Person {
+  name: string;
+  email: string;
+  phone: string;
+  calendarId: string;
+}

--- a/src/models/__tests__/chef.test.ts
+++ b/src/models/__tests__/chef.test.ts
@@ -1,0 +1,45 @@
+import moment from 'moment';
+import { Person } from '@/interfaces';
+import { Chef, Event } from '..';
+
+const person: Person = {
+  name: 'Hank',
+  email: 'hank@hill.com',
+  phone: '18885556969',
+  calendarId: 'my-calendar',
+};
+
+const exclusions = [
+  new Event({
+    summary: 'my Monday event',
+    date: moment()
+      .day(8)
+      .toDate(),
+  }),
+  new Event({
+    summary: 'my Tuesday event',
+    date: moment()
+      .day(9)
+      .toDate(),
+  }),
+];
+
+const chef = new Chef(person, exclusions);
+
+describe('model: Chef', () => {
+  describe('constructor', () => {
+    it('assigns properties from the passed-in Person', () => {
+      Object.keys(person).forEach(key => {
+        expect(person[key]).toBe(chef[key]);
+      });
+    });
+  });
+
+  describe('getters', () => {
+    describe('excludedDaysNextWeek', () => {
+      it('returns days of exclusions next week', () => {
+        expect(chef.excludedDaysNextWeek).toStrictEqual([8, 9]);
+      });
+    });
+  });
+});

--- a/src/models/__tests__/chef.test.ts
+++ b/src/models/__tests__/chef.test.ts
@@ -12,15 +12,11 @@ const person: Person = {
 const exclusions = [
   new Event({
     summary: 'my Monday event',
-    date: moment()
-      .day(8)
-      .toDate(),
+    start: moment().day(8),
   }),
   new Event({
     summary: 'my Tuesday event',
-    date: moment()
-      .day(9)
-      .toDate(),
+    start: moment().day(9),
   }),
 ];
 

--- a/src/models/__tests__/event-date-time.test.ts
+++ b/src/models/__tests__/event-date-time.test.ts
@@ -4,7 +4,7 @@ import { EventDateTime } from '..';
 describe('model: EventDateTime', () => {
   describe('constructor', () => {
     it('formats date as Google expects', () => {
-      const { date } = new EventDateTime(moment().toDate());
+      const { date } = new EventDateTime(moment());
       expect(moment(date, EventDateTime.dateFormat).isValid()).toBe(true);
     });
   });

--- a/src/models/__tests__/event.test.ts
+++ b/src/models/__tests__/event.test.ts
@@ -3,8 +3,9 @@ import { Event, EventDateTime } from '..';
 
 describe('model: Event', () => {
   const summary = 'my event';
-  const date = moment().toDate();
-  const event = new Event({ summary, date });
+  const start = moment();
+  const end = moment().add(1, 'day');
+  let event = new Event({ summary, start });
 
   describe('constructor', () => {
     it('sets the summary of the event', () => {
@@ -16,9 +17,16 @@ describe('model: Event', () => {
       expect(event.end).toBeInstanceOf(EventDateTime);
     });
 
-    it('sets the start date equal to the end date', () => {
-      expect(event.start.date).toBe(moment(date).format(EventDateTime.dateFormat));
+    it('sets the start date equal to the end date by default', () => {
+      expect(event.start.date).toBe(start.format(EventDateTime.dateFormat));
       expect(event.start).toBe(event.end);
+    });
+
+    it('sets the passed-in end date', () => {
+      event = new Event({ summary, start, end });
+      expect(event.start.date).toBe(start.format(EventDateTime.dateFormat));
+      expect(event.end.date).toBe(end.format(EventDateTime.dateFormat));
+      expect(event.start).not.toBe(event.end);
     });
   });
 });

--- a/src/models/__tests__/schedule.test.ts
+++ b/src/models/__tests__/schedule.test.ts
@@ -16,7 +16,7 @@ describe('model: Schedule', () => {
         .format('YYYY-MM-DD');
       const schedule = Schedule.fromScheduleItems([scheduleItem], date);
 
-      it('returns a new Schedule instance', () => {
+      it('returns a Schedule instance', () => {
         expect(schedule).toBeInstanceOf(Schedule);
       });
 

--- a/src/models/chef.ts
+++ b/src/models/chef.ts
@@ -1,0 +1,35 @@
+import moment from 'moment';
+import { Person } from '@/interfaces';
+import EventDateTime from './event-date-time';
+import Event from './event';
+
+export default class Chef implements Person {
+  name: string;
+  email: string;
+  phone: string;
+  calendarId: string;
+
+  exclusions: Event[];
+
+  get excludedDaysNextWeek() {
+    return this.exclusions.reduce((days, { start, end }) => {
+      const startDay = moment(start.date, EventDateTime.dateFormat).day() + 7;
+      const endDay = moment(end.date, EventDateTime.dateFormat).day() + 7;
+      if (startDay === endDay) {
+        days.push(startDay);
+      } else {
+        for (let day = startDay; day <= endDay; day++) {
+          days.push(day);
+        }
+      }
+      return days;
+    }, [] as number[]);
+  }
+
+  score?: number; // TODO score will depend on cooking history
+
+  constructor(person: Person, exclusions = [] as Event[]) {
+    Object.assign(this, person);
+    this.exclusions = exclusions;
+  }
+}

--- a/src/models/event-date-time.ts
+++ b/src/models/event-date-time.ts
@@ -1,5 +1,5 @@
 import { calendar_v3 as calendarV3 } from 'googleapis/build/src/apis/calendar/v3';
-import moment from 'moment';
+import { Moment } from 'moment';
 
 /** Represents a date conforming to the Google Calendar API's `EventDateTime` type interface. */
 export default class EventDateTime implements calendarV3.Schema$EventDateTime {
@@ -10,9 +10,9 @@ export default class EventDateTime implements calendarV3.Schema$EventDateTime {
   /**
    * Create an EventDateTime for an all-day Google Calendar event
    *
-   * @param {Date} date Day on which the all-day event falls
+   * @param {Moment} date Day on which the all-day event falls
    */
-  constructor(date: Date) {
-    this.date = moment(date).format(EventDateTime.dateFormat);
+  constructor(date: Moment) {
+    this.date = date.format(EventDateTime.dateFormat);
   }
 }

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -1,21 +1,30 @@
 import { calendar_v3 as calendarV3 } from 'googleapis/build/src/apis/calendar/v3';
+import { Moment } from 'moment';
 import EventDateTime from './event-date-time';
 
-/** Represents a calendar event conforming to the Google Calendar API's Event type interface. */
+interface EventDetails {
+  summary: string;
+  start: Moment;
+  end?: Moment;
+  description?: string;
+}
+
+/** Represents a calendar event conforming to the Google Calendar API's `Event` type interface. */
 export default class Event implements calendarV3.Schema$Event {
+  summary: string;
   start: EventDateTime;
   end: EventDateTime;
-  summary: string;
   description?: string;
 
   /**
-   * Create an all-day Google Calendar event ready to be added to a calendar
+   * Create a Google Calendar event ready to be added to a calendar
    *
    * @param eventDetails Summary and date on which the all-day event falls
    */
-  constructor({ summary, date }: { summary: string; date: Date }) {
+  constructor({ summary, start, end = start, description }: EventDetails) {
     this.summary = summary;
-    this.start = new EventDateTime(date);
-    this.end = this.start;
+    this.start = new EventDateTime(start);
+    this.end = end === start ? this.start : new EventDateTime(end);
+    this.description = description;
   }
 }

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,3 +1,4 @@
+export { default as Chef } from './chef';
 export { default as EventDateTime } from './event-date-time';
 export { default as Event } from './event';
 export { default as Schedule } from './schedule';

--- a/src/models/schedule.ts
+++ b/src/models/schedule.ts
@@ -1,29 +1,31 @@
 import moment from 'moment';
 import { ScheduleItem } from '@/interfaces';
+import { capitalize } from '@/utils';
 import Event from './event';
-import capitalize from '@/utils/capitalize';
 
-/** Maps day of the week to 0–4 numeric value */
+/** Maps day of the week to 0–6 numeric value */
 enum days {
   SUN,
   MON,
   TUE,
   WED,
   THU,
+  FRI,
+  SAT,
 }
 
 /** Represents a collection of Google Calendar events */
 export default class Schedule {
-  constructor(public events: Event[]) {}
+  private constructor(public events: Event[]) {}
 
   /** Construct a new Schedule from data conforming to the chef-cal-integration external API */
-  static fromScheduleItems(scheduleItems: ScheduleItem[], start: string): Schedule {
+  static fromScheduleItems(scheduleItems: ScheduleItem[], startDateString: string) {
     return new Schedule(
       scheduleItems.map(({ type, chef, day }) => {
         const summary = `${capitalize(type)} — ${capitalize(chef)}`;
-        const date = moment(start, 'YYYY-MM-DD');
-        date.add(days[day.toUpperCase()], 'days');
-        return new Event({ summary, date: date.toDate() });
+        const start = moment(startDateString, 'YYYY-MM-DD');
+        start.add(days[day.toUpperCase()], 'days');
+        return new Event({ summary, start });
       }),
     );
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,7 @@
 import 'module-alias/register';
 import app from '@/app';
 
-const port = process.env.PORT ?? '4003';
+const port = process.env.PORT || '4003';
 // eslint-disable-next-line no-console
 const server = app.listen(port, () => console.log(`listening on ${port}`));
 

--- a/src/services/__tests__/google-calendar.test.ts
+++ b/src/services/__tests__/google-calendar.test.ts
@@ -1,6 +1,7 @@
 import { google } from 'googleapis';
-import { GoogleCalendarService } from '..';
+import moment from 'moment';
 import { Event } from '@/models';
+import { GoogleCalendarService } from '..';
 
 jest.mock('twilio');
 jest.mock('googleapis', () => {
@@ -28,8 +29,8 @@ describe('service: GoogleCalendarService', () => {
   describe('methods', () => {
     describe('static addEvents', () => {
       const events = [
-        new Event({ summary: 'my event', date: new Date() }),
-        new Event({ summary: 'my other event', date: new Date() }),
+        new Event({ summary: 'my event', start: moment() }),
+        new Event({ summary: 'my other event', start: moment() }),
       ];
 
       beforeEach(async () => {

--- a/src/services/google-calendar.ts
+++ b/src/services/google-calendar.ts
@@ -4,17 +4,18 @@ import { Event } from '@/models';
 
 /** Interface for Google's Calendar API */
 export default class GoogleCalendarService {
+  /** APIs for Google Calendar */
+  private static readonly chefSchedule = google.calendar('v3');
+
   /** Provides service account authentication for Google Calendar */
   private static readonly googleAuthInstance = new google.auth.GoogleAuth({
     credentials: JSON.parse(process.env.CREDENTIALS),
     scopes: ['https://www.googleapis.com/auth/calendar'],
   });
 
-  /** Events API for Google Calendar */
-  private static readonly calendarEvents = google.calendar('v3').events;
-
   /** Obtain a JWT to authenticate Google Calendar requests */
   private static getJWT() {
+    // TODO reuse token and refresh only as needed
     return this.googleAuthInstance.getClient() as Promise<JWT>;
   }
 
@@ -27,11 +28,7 @@ export default class GoogleCalendarService {
   static async addEvents(events: Event[], calendarId = 'primary') {
     const auth = await this.getJWT();
     const requests = events.map(event =>
-      this.calendarEvents.insert({
-        auth,
-        calendarId,
-        requestBody: event,
-      }),
+      this.chefSchedule.events.insert({ auth, calendarId, requestBody: event }),
     );
     await Promise.all(requests);
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "CommonJS",
+    "moduleResolution": "node",
     "esModuleInterop": true,
     "sourceMap": true,
     "typeRoots": ["node_modules/@types", "src/@types"],


### PR DESCRIPTION
Write a `Chef` model in preparation for generating more intelligent schedules. Refactor `EventDateTime` to accept a `Moment` instead of a `Date` in its constructor, and adjust the dependent models, services, and tests accordingly. Make a few configuration adjustments.