### PR TITLE
Generate ChefSchedule from chefs' availability

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
   "env": { "node": true },
-  "extends": ["airbnb-base", "plugin:jest/all"],
+  "extends": ["airbnb-base", "plugin:jest/all", "prettier"],
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint"],
   "settings": {
@@ -16,18 +16,15 @@
     "@typescript-eslint/no-useless-constructor": "error",
     "arrow-parens": ["error", "as-needed"],
     "comma-dangle": ["error", "always-multiline"],
-    "function-paren-newline": "off",
-    "implicit-arrow-linebreak": "off",
     "import/extensions": "off",
     "import/prefer-default-export": "off",
     "jest/no-hooks": "off",
     "jest/prefer-expect-assertions": "off",
-    "lines-between-class-members": "off",
+    "lines-between-class-members": ["error", "always", { "exceptAfterSingleLine": true }],
     "no-empty": "off",
     "no-empty-function": "off",
     "no-plusplus": "off",
     "no-return-await": "off",
-    "no-underscore-dangle": "off",
     "no-unused-vars": "off",
     "no-useless-constructor": "off",
     "object-curly-newline": ["error", { "multiline": true }]

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,7 @@ jobs:
   include:
     - name: 'Package audit'
       script: npm audit
-    - name: 'Tests'
+    - name: 'Lint'
+      script: npm run lint
+    - name: 'Test'
       script: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -3270,6 +3270,15 @@
         "object.entries": "^1.1.0"
       }
     },
+    "eslint-config-prettier": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz",
+      "integrity": "sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^6.0.0"
+      }
+    },
     "eslint-import-resolver-node": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz",
@@ -4629,6 +4638,12 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
       "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
       "dev": true
     },
     "get-stream": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "docs": "rm -rf docs && jsdoc -c jsdoc.json -d docs -r && open docs/index.html",
     "lint": "eslint src --ext ts",
-    "format": "prettier --write \"**/*@(.ts|.js|.md)\"",
+    "format": "prettier --write \"**/*@(.ts|.js|.md)\" && npm run lint -- --fix",
     "build": "rm -rf dist && webpack",
     "build:watch": "npm run build -- -w",
     "start": "node dist",
@@ -43,6 +43,7 @@
     "circular-dependency-plugin": "^5.2.0",
     "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "^14.0.0",
+    "eslint-config-prettier": "^6.10.0",
     "eslint-import-resolver-typescript": "^2.0.0",
     "eslint-plugin-import": "^2.20.0",
     "eslint-plugin-jest": "^22.21.0",

--- a/src/@types/nodejs.d.ts
+++ b/src/@types/nodejs.d.ts
@@ -7,7 +7,7 @@ declare namespace NodeJS {
     /** Phone number from which chef-cal-integration SMS messages will be sent */
     readonly HOST_NUMBER: string;
     /** Array of people used until a DB solution becomes necessary */
-    readonly PEOPLE: string;
+    PEOPLE: string;
     /** Credentials to authenticate as a Google service account */
     readonly CREDENTIALS: string;
     /** Current runtime environment */

--- a/src/models/__tests__/chef-schedule.test.ts
+++ b/src/models/__tests__/chef-schedule.test.ts
@@ -1,6 +1,26 @@
 import moment from 'moment';
-import { ScheduleItem } from '@/interfaces';
-import { ChefSchedule } from '..';
+import { Person, ScheduleItem } from '@/interfaces';
+import { GoogleCalendarService } from '@/services';
+import { ChefSchedule, Chef } from '..';
+
+jest
+  .spyOn(GoogleCalendarService, 'queryAndSetChefsAvailabilityNextWeek')
+  .mockImplementation(async (chefs: Chef[]) => {
+    chefs.forEach((chef, i) => {
+      Object.keys(chef.availabilityNextWeek).forEach(day => {
+        // eslint-disable-next-line no-param-reassign
+        chef.availabilityNextWeek[day] = +day === i + 7;
+      });
+    });
+  });
+
+const people: Person[] = [
+  { name: 'Terri', email: '', phone: '', calendarId: '0' },
+  { name: 'Larry', email: '', phone: '', calendarId: '1' },
+  { name: 'Harry', email: '', phone: '', calendarId: '2' },
+  { name: 'Barry', email: '', phone: '', calendarId: '3' },
+  { name: 'Cheri', email: '', phone: '', calendarId: '4' },
+];
 
 const scheduleItem: ScheduleItem = {
   type: 'Main',
@@ -10,10 +30,57 @@ const scheduleItem: ScheduleItem = {
 
 describe('model: ChefSchedule', () => {
   describe('methods', () => {
+    describe('static generate', () => {
+      let schedule: ChefSchedule;
+      let PEOPLE: string;
+
+      beforeAll(async () => {
+        PEOPLE = process.env.PEOPLE;
+        process.env.PEOPLE = JSON.stringify(people);
+        schedule = await ChefSchedule.generate();
+      });
+
+      afterAll(() => {
+        process.env.PEOPLE = PEOPLE;
+      });
+
+      it('returns a ChefSchedule instance', () => {
+        expect(schedule).toBeInstanceOf(ChefSchedule);
+      });
+
+      it('schedules an event for each of Sunday–Thursday', () => {
+        schedule.events.sort(
+          (a, b) =>
+            +moment(a.start.date, 'YYYY-MM-DD').format('d') -
+            +moment(b.start.date, 'YYYY-MM-DD').format('d'),
+        );
+        schedule.events.forEach((event, i) => {
+          const day = +moment(event.start.date, 'YYYY-MM-DD').format('d');
+          expect(day).toBe(i);
+        });
+      });
+
+      // TODO handle cases when there are fewer chefs than days to assign
+      it('assigns each chef at most one event', () => {
+        const chefs = new Set();
+        schedule.events.forEach(event => chefs.add(event.summary));
+        expect(chefs.size).toBe(schedule.events.length);
+      });
+
+      it('does not schedule a chef to cook on a day they are busy', () => {
+        schedule.events.sort(
+          (a, b) =>
+            +moment(a.start.date, 'YYYY-MM-DD').format('d') -
+            +moment(b.start.date, 'YYYY-MM-DD').format('d'),
+        );
+        schedule.events.forEach((event, i) => expect(event.summary.includes(people[i].name)));
+      });
+    });
+
     describe('static generateRandom', () => {
       const schedule = ChefSchedule.generateRandom();
 
-      it('returns a Schedule instance', () => {
+      it('returns a ChefSchedule instance', () => {
         expect(schedule).toBeInstanceOf(ChefSchedule);
       });
 
@@ -38,7 +105,7 @@ describe('model: ChefSchedule', () => {
         .format('YYYY-MM-DD');
       const schedule = ChefSchedule.fromScheduleItems([scheduleItem], date);
 
-      it('returns a Schedule instance', () => {
+      it('returns a ChefSchedule instance', () => {
         expect(schedule).toBeInstanceOf(ChefSchedule);
       });
 

--- a/src/models/__tests__/chef-schedule.test.ts
+++ b/src/models/__tests__/chef-schedule.test.ts
@@ -33,8 +33,8 @@ const scheduleItem: ScheduleItem = {
 describe('model: ChefSchedule', () => {
   describe('methods', () => {
     describe('static generate', () => {
-      let schedule: ChefSchedule;
       let PEOPLE: string;
+      let schedule: ChefSchedule;
 
       beforeAll(async () => {
         PEOPLE = process.env.PEOPLE;

--- a/src/models/__tests__/chef-schedule.test.ts
+++ b/src/models/__tests__/chef-schedule.test.ts
@@ -3,6 +3,8 @@ import { Person, ScheduleItem } from '@/interfaces';
 import { GoogleCalendarService } from '@/services';
 import { ChefSchedule, Chef } from '..';
 
+// FIXME correctly sandbox so this doesn't need to be mocked
+jest.mock('twilio');
 jest
   .spyOn(GoogleCalendarService, 'queryAndSetChefsAvailabilityNextWeek')
   .mockImplementation(async (chefs: Chef[]) => {

--- a/src/models/__tests__/chef.test.ts
+++ b/src/models/__tests__/chef.test.ts
@@ -3,6 +3,9 @@ import moment from 'moment';
 import { Person } from '@/interfaces';
 import { Chef } from '..';
 
+// FIXME correctly sandbox so this doesn't need to be mocked
+jest.mock('twilio');
+
 const person: Person = {
   name: 'Hank',
   email: 'hank@hill.com',

--- a/src/models/__tests__/chef.test.ts
+++ b/src/models/__tests__/chef.test.ts
@@ -10,9 +10,41 @@ const person: Person = {
   calendarId: 'my-calendar',
 };
 
-const chef = new Chef(person);
+let chef: Chef;
+const busyPeriods: calendarV3.Schema$TimePeriod[] = [
+  {
+    start: moment()
+      .day(8)
+      .format(),
+    end: moment()
+      .day(8)
+      .format(),
+  },
+  {
+    start: moment()
+      .day(10)
+      .format(),
+    end: moment()
+      .day(12)
+      .format(),
+  },
+];
 
 describe('model: Chef', () => {
+  beforeEach(() => {
+    chef = new Chef(person);
+  });
+
+  describe('getters', () => {
+    describe('availabilityScore', () => {
+      it('returns normalized sum of days chef is available to cook', () => {
+        expect(chef.availabilityScore).toBe(1);
+        chef.setAvailabilityNextWeek(busyPeriods);
+        expect(chef.availabilityScore).toBe(3 / 7);
+      });
+    });
+  });
+
   describe('constructor', () => {
     it('assigns properties from the passed-in Person', () => {
       Object.keys(person).forEach(key => {
@@ -23,25 +55,6 @@ describe('model: Chef', () => {
 
   describe('methods', () => {
     describe('setAvailabilityNextWeek', () => {
-      const busyPeriods: calendarV3.Schema$TimePeriod[] = [
-        {
-          start: moment()
-            .day(8)
-            .format(),
-          end: moment()
-            .day(8)
-            .format(),
-        },
-        {
-          start: moment()
-            .day(10)
-            .format(),
-          end: moment()
-            .day(12)
-            .format(),
-        },
-      ];
-
       it('sets availability of each busy day to "false"', () => {
         Object.keys(chef.availabilityNextWeek).forEach(day => {
           expect(chef.availabilityNextWeek[day]).toBe(true);

--- a/src/models/__tests__/event-date-time.test.ts
+++ b/src/models/__tests__/event-date-time.test.ts
@@ -1,6 +1,9 @@
 import moment from 'moment';
 import { EventDateTime } from '..';
 
+// FIXME correctly sandbox so this doesn't need to be mocked
+jest.mock('twilio');
+
 describe('model: EventDateTime', () => {
   describe('constructor', () => {
     it('formats date as Google expects', () => {

--- a/src/models/__tests__/event.test.ts
+++ b/src/models/__tests__/event.test.ts
@@ -1,6 +1,9 @@
 import moment from 'moment';
 import { Event, EventDateTime } from '..';
 
+// FIXME correctly sandbox so this doesn't need to be mocked
+jest.mock('twilio');
+
 describe('model: Event', () => {
   const summary = 'my event';
   const start = moment();

--- a/src/models/chef.ts
+++ b/src/models/chef.ts
@@ -18,6 +18,7 @@ export default class Chef implements Person {
     12: true, // Friday
     13: true, // Saturday
   };
+
   /** Score representing how frequently Chef has cooked */
   // TODO implement cookFrequency
   cookFrequency?: number;

--- a/src/models/chef.ts
+++ b/src/models/chef.ts
@@ -25,7 +25,7 @@ export default class Chef implements Person {
   get availabilityScore() {
     return (
       Object.keys(this.availabilityNextWeek).reduce(
-        (score, day) => (this.availabilityNextWeek[day] ? score : score + 1),
+        (score, day) => (this.availabilityNextWeek[day] ? score + 1 : score),
         0,
       ) / 7
     );

--- a/src/models/chef.ts
+++ b/src/models/chef.ts
@@ -18,8 +18,18 @@ export default class Chef implements Person {
     12: true, // Friday
     13: true, // Saturday
   };
-
-  score?: number; // TODO score will depend on cooking history
+  /** Score representing how frequently Chef has cooked */
+  // TODO implement cookFrequency
+  cookFrequency?: number;
+  /** Score representing how available Chef is to cook next week */
+  get availabilityScore() {
+    return (
+      Object.keys(this.availabilityNextWeek).reduce(
+        (score, day) => (this.availabilityNextWeek[day] ? score : score + 1),
+        0,
+      ) / 7
+    );
+  }
 
   constructor(person: Person) {
     Object.assign(this, person);

--- a/src/models/schedule/chef-schedule.ts
+++ b/src/models/schedule/chef-schedule.ts
@@ -8,7 +8,9 @@ import Schedule, { days } from './schedule';
 
 export default class ChefSchedule extends Schedule {
   private static numDaysToAssign = 5; // Sunday–Thursday
-  private static people = JSON.parse(process.env.PEOPLE || '[]') as Person[];
+  private static get people() {
+    return JSON.parse(process.env.PEOPLE || '[]') as Person[];
+  }
 
   static summary(chef: string | Chef, mealType = 'Main') {
     return `${capitalize(mealType)} — ${capitalize(chef instanceof Chef ? chef.name : chef)}`;

--- a/src/models/schedule/chef-schedule.ts
+++ b/src/models/schedule/chef-schedule.ts
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import { Person, ScheduleItem } from '@/interfaces';
+import { GoogleCalendarService } from '@/services';
 import { capitalize } from '@/utils';
 import Chef from '../chef';
 import Event from '../event';
@@ -13,8 +14,41 @@ export default class ChefSchedule extends Schedule {
     return `${capitalize(mealType)} — ${capitalize(chef instanceof Chef ? chef.name : chef)}`;
   }
 
-  /** Construct a new Schedule, assigning each chef to one day randomly */
-  // TODO handle repeat cooking days when # chefs fewer than days to cook
+  /** Construct a ChefSchedule, taking chefs' availability into account */
+  // TODO handle repeat cooking days when # chefs fewer than # days to cook
+  static async generate() {
+    const chefs = this.people.map(person => new Chef(person));
+    const daysToAssign = Array.from(Array(this.numDaysToAssign), (_, i) => i + 7);
+    await GoogleCalendarService.queryAndSetChefsAvailabilityNextWeek(chefs);
+    const selectedChefs = Array.from(daysToAssign, () => {
+      let chef: Chef;
+
+      while (!chef && chefs.length) {
+        const i = Math.floor(Math.random() * chefs.length);
+        const [selectedChef] = chefs.splice(i, 1);
+        // if selectedChef has any availability, preserve the selection
+        if (selectedChef.availabilityScore > 0) {
+          chef = selectedChef;
+        }
+      }
+
+      return chef;
+    });
+
+    selectedChefs.sort((a, b) => a.availabilityScore - b.availabilityScore);
+    return new ChefSchedule(
+      selectedChefs.map(chef => {
+        const summary = this.summary(chef);
+        const i = daysToAssign.findIndex(dayToAssign => chef.availabilityNextWeek[dayToAssign]);
+        const [day] = daysToAssign.splice(i, 1);
+        const start = moment().day(day);
+        return new Event({ summary, start });
+      }),
+    );
+  }
+
+  /** Construct a ChefSchedule, assigning each chef to one day randomly */
+  // TODO handle repeat cooking days when # chefs fewer than # days to cook
   static generateRandom() {
     const people = [...this.people];
     const assignedChefs: Chef[] = [];

--- a/src/models/schedule/chef-schedule.ts
+++ b/src/models/schedule/chef-schedule.ts
@@ -19,8 +19,8 @@ export default class ChefSchedule extends Schedule {
   /** Construct a ChefSchedule, taking chefs' availability into account */
   // TODO handle repeat cooking days when # chefs fewer than # days to cook
   static async generate() {
-    const chefs = this.people.map(person => new Chef(person));
     const daysToAssign = Array.from(Array(this.numDaysToAssign), (_, i) => i + 7);
+    const chefs = this.people.map(person => new Chef(person));
     await GoogleCalendarService.queryAndSetChefsAvailabilityNextWeek(chefs);
     const selectedChefs = Array.from(daysToAssign, () => {
       let chef: Chef;

--- a/src/services/__tests__/twilio.test.ts
+++ b/src/services/__tests__/twilio.test.ts
@@ -3,9 +3,7 @@ import { TwilioService } from '..';
 
 jest.mock('twilio', () => {
   const mockCreate = jest.fn();
-  return () => ({
-    messages: { create: mockCreate },
-  });
+  return () => ({ messages: { create: mockCreate } });
 });
 
 const mockCreate = createClient().messages.create as jest.Mock;

--- a/src/services/google-calendar.ts
+++ b/src/services/google-calendar.ts
@@ -1,6 +1,6 @@
-import moment from 'moment';
 import { JWT } from 'google-auth-library';
 import { google } from 'googleapis';
+import moment from 'moment';
 import { Chef, Event } from '@/models';
 
 /** Interface for Google's Calendar API */


### PR DESCRIPTION
Query chefs' availability for the next week from Google Calendar. Sort chefs by availability, and assign each chef a day to cook next week.