### PR TITLE
Create task to run each Friday & generate schedule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -770,6 +770,15 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.25.tgz",
       "integrity": "sha512-nf1LMGZvgFX186geVZR1xMZKKblJiRfiASTHw85zED2kI1yDKHDwTKMdkaCbTlXoRKlGKaDfYywt+V0As30q3w=="
     },
+    "@types/node-cron": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/node-cron/-/node-cron-2.0.2.tgz",
+      "integrity": "sha512-JE16Xfkuwecu8++rjW1+KSJYKaEAJA5v4JwbYJGN/z4Qb09GkDeeI+cJGWWrsoxocU8/FIUwRJnTnU+I5fPoag==",
+      "dev": true,
+      "requires": {
+        "@types/tz-offset": "*"
+      }
+    },
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
@@ -814,6 +823,12 @@
       "requires": {
         "@types/superagent": "*"
       }
+    },
+    "@types/tz-offset": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@types/tz-offset/-/tz-offset-0.0.0.tgz",
+      "integrity": "sha512-XLD/llTSB6EBe3thkN+/I0L+yCTB6sjrcVovQdx2Cnl6N6bTzHmwe/J8mWnsXFgxLrj/emzdv8IR4evKYG2qxQ==",
+      "dev": true
     },
     "@types/yargs": {
       "version": "13.0.2",
@@ -7499,6 +7514,15 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-cron": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-2.0.3.tgz",
+      "integrity": "sha512-eJI+QitXlwcgiZwNNSRbqsjeZMp5shyajMR81RZCqeW0ZDEj4zU9tpd4nTh/1JsBiKbF8d08FCewiipDmVIYjg==",
+      "requires": {
+        "opencollective-postinstall": "^2.0.0",
+        "tz-offset": "0.0.1"
+      }
+    },
     "node-fetch": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
@@ -7986,8 +8010,7 @@
     "opencollective-postinstall": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
-      "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==",
-      "dev": true
+      "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw=="
     },
     "optionator": {
       "version": "0.8.3",
@@ -10314,6 +10337,11 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
       "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
       "dev": true
+    },
+    "tz-offset": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/tz-offset/-/tz-offset-0.0.1.tgz",
+      "integrity": "sha512-kMBmblijHJXyOpKzgDhKx9INYU4u4E1RPMB0HqmKSgWG8vEcf3exEfLh4FFfzd3xdQOw9EuIy/cP0akY6rHopQ=="
     },
     "uc.micro": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "googleapis": "^47.0.0",
     "module-alias": "^2.2.2",
     "moment": "^2.24.0",
+    "node-cron": "^2.0.3",
     "twilio": "^3.39.3"
   },
   "devDependencies": {
@@ -36,6 +37,7 @@
     "@types/express": "^4.17.2",
     "@types/jest": "^24.9.0",
     "@types/node": "^12.12.25",
+    "@types/node-cron": "^2.0.2",
     "@types/supertest": "^2.0.8",
     "@typescript-eslint/eslint-plugin": "^2.17.0",
     "@typescript-eslint/parser": "^2.17.0",

--- a/src/@types/nodejs.d.ts
+++ b/src/@types/nodejs.d.ts
@@ -6,13 +6,13 @@ declare namespace NodeJS {
     readonly AUTH_TOKEN: string;
     /** Phone number from which chef-cal-integration SMS messages will be sent */
     readonly HOST_NUMBER: string;
-    /** Array of people used until a DB solution becomes necessary */
-    PEOPLE: string;
     /** Credentials to authenticate as a Google service account */
     readonly CREDENTIALS: string;
     /** Current runtime environment */
     readonly NODE_ENV: string;
     /** Port at which the express app will listen */
     readonly PORT: string;
+    /** Array of people used until a DB solution becomes necessary */
+    PEOPLE: string;
   }
 }

--- a/src/__tests__/app.test.ts
+++ b/src/__tests__/app.test.ts
@@ -17,7 +17,7 @@ const requestBody = {
   schedule: scheduleItems,
 };
 
-describe('express server', () => {
+describe('express app', () => {
   afterAll(() => server.close());
 
   describe('endpoints', () => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -30,7 +30,7 @@ if (process.env.NODE_ENV === 'production') {
       await GoogleCalendarService.addEvents(events);
       await TwilioService.sendGroupSMS({
         body:
-          'A new Chef Schedule is available! Visit https://bit.ly/37bMa48 to see if/when you cook next week!',
+          'A new Chef Schedule is available! Visit https://bit.ly/37bMa48 to see if/when you cook next week.',
         toGroup: people.map(person => person.phone),
       });
     } catch (error) {}

--- a/src/app.ts
+++ b/src/app.ts
@@ -22,17 +22,19 @@ app.post('/schedule', async ({ body }, res) => {
   }
 });
 
-createTask('* * * * Friday', async () => {
-  try {
-    const people = JSON.parse(process.env.PEOPLE) as Person[];
-    const { events } = await ChefSchedule.generate();
-    await GoogleCalendarService.addEvents(events);
-    await TwilioService.sendGroupSMS({
-      body:
-        'A new Chef Schedule is available! Visit https://bit.ly/37bMa48 to see if/when you cook next week!',
-      toGroup: people.map(person => person.phone),
-    });
-  } catch (error) {}
-});
+if (process.env.NODE_ENV === 'production') {
+  createTask('* * * * Friday', async () => {
+    try {
+      const people = JSON.parse(process.env.PEOPLE) as Person[];
+      const { events } = await ChefSchedule.generate();
+      await GoogleCalendarService.addEvents(events);
+      await TwilioService.sendGroupSMS({
+        body:
+          'A new Chef Schedule is available! Visit https://bit.ly/37bMa48 to see if/when you cook next week!',
+        toGroup: people.map(person => person.phone),
+      });
+    } catch (error) {}
+  });
+}
 
 export default app;

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,8 @@
 import express from 'express';
-import { ScheduleRequestBody } from '@/interfaces';
+import { schedule as createTask } from 'node-cron';
+import { Person, ScheduleRequestBody } from '@/interfaces';
 import { ChefSchedule } from '@/models';
-import { GoogleCalendarService } from '@/services';
+import { GoogleCalendarService, TwilioService } from '@/services';
 
 const app = express();
 
@@ -19,6 +20,19 @@ app.post('/schedule', async ({ body }, res) => {
   } catch (err) {
     res.sendStatus(400);
   }
+});
+
+createTask('* * * * Friday', async () => {
+  try {
+    const people = JSON.parse(process.env.PEOPLE) as Person[];
+    const { events } = await ChefSchedule.generate();
+    await GoogleCalendarService.addEvents(events);
+    await TwilioService.sendGroupSMS({
+      body:
+        'A new Chef Schedule is available! Visit https://bit.ly/37bMa48 to see if/when you cook next week!',
+      toGroup: people.map(person => person.phone),
+    });
+  } catch (error) {}
 });
 
 export default app;

--- a/src/models/__tests__/chef.test.ts
+++ b/src/models/__tests__/chef.test.ts
@@ -43,7 +43,7 @@ describe('model: Chef', () => {
       it('returns normalized sum of days chef is available to cook', () => {
         expect(chef.availabilityScore).toBe(1);
         chef.setAvailabilityNextWeek(busyPeriods);
-        expect(chef.availabilityScore).toBe(3 / 7);
+        expect(chef.availabilityScore).toBe(2 / 5);
       });
     });
   });

--- a/src/models/chef.ts
+++ b/src/models/chef.ts
@@ -15,21 +15,22 @@ export default class Chef implements Person {
     9: true, //  Tuesday
     10: true, // Wednesday
     11: true, // Thursday
-    12: true, // Friday
-    13: true, // Saturday
+    // TODO programmatically exclude these days
+    // 12: true, // Friday
+    // 13: true, // Saturday
   };
 
   /** Score representing how frequently Chef has cooked */
   // TODO implement cookFrequency
   cookFrequency?: number;
   /** Score representing how available Chef is to cook next week */
-  // TODO exclude days not cooked in score (Friday, Saturday)
+  // TODO don't hardcode number of days per week to cook
   get availabilityScore() {
     return (
       Object.keys(this.availabilityNextWeek).reduce(
         (score, day) => (this.availabilityNextWeek[day] ? score + 1 : score),
         0,
-      ) / 7
+      ) / 5
     );
   }
 

--- a/src/models/chef.ts
+++ b/src/models/chef.ts
@@ -23,6 +23,7 @@ export default class Chef implements Person {
   // TODO implement cookFrequency
   cookFrequency?: number;
   /** Score representing how available Chef is to cook next week */
+  // TODO exclude days not cooked in score (Friday, Saturday)
   get availabilityScore() {
     return (
       Object.keys(this.availabilityNextWeek).reduce(

--- a/src/models/schedule/chef-schedule.ts
+++ b/src/models/schedule/chef-schedule.ts
@@ -35,7 +35,7 @@ export default class ChefSchedule extends Schedule {
       }
 
       return chef;
-    });
+    }).filter(chef => !!chef);
 
     selectedChefs.sort((a, b) => a.availabilityScore - b.availabilityScore);
     return new ChefSchedule(

--- a/src/models/schedule/chef-schedule.ts
+++ b/src/models/schedule/chef-schedule.ts
@@ -9,7 +9,7 @@ import Schedule, { days } from './schedule';
 export default class ChefSchedule extends Schedule {
   private static numDaysToAssign = 5; // Sunday–Thursday
   private static get people() {
-    return JSON.parse(process.env.PEOPLE || '[]') as Person[];
+    return JSON.parse(process.env.PEOPLE) as Person[];
   }
 
   static summary(chef: string | Chef, mealType = 'Main') {
@@ -76,7 +76,7 @@ export default class ChefSchedule extends Schedule {
   /** Construct a ChefSchedule from data conforming to the chef-cal-integration external API */
   static fromScheduleItems(scheduleItems: ScheduleItem[], startDateString: string) {
     return new ChefSchedule(
-      scheduleItems.map(({ chef, day, type = 'Main' }) => {
+      scheduleItems.map(({ chef, day, type }) => {
         const summary = this.summary(chef, type);
         const start = moment(startDateString, 'YYYY-MM-DD');
         start.add(days[day.toUpperCase()], 'days');

--- a/src/services/__tests__/google-calendar.test.ts
+++ b/src/services/__tests__/google-calendar.test.ts
@@ -7,14 +7,9 @@ jest.mock('twilio');
 jest.mock('googleapis', () => {
   const mockAclInsert = jest.fn();
   const mockEventsInsert = jest.fn();
-  const mockFreeBusyQuery = jest.fn().mockResolvedValue({
-    data: {
-      calendars: {
-        'hank-calendar': { busy: [] },
-        'mary-calendar': { busy: [] },
-      },
-    },
-  });
+  const mockFreeBusyQuery = jest
+    .fn()
+    .mockResolvedValue({ data: { calendars: { 'hank-calendar': { busy: [] } } } });
   return {
     google: {
       auth: {
@@ -133,15 +128,14 @@ describe('service: GoogleCalendarService', () => {
     });
 
     describe('static queryAndSetChefsAvailabilityNextWeek', () => {
-      const chefs = [
-        new Chef({ name: 'Hank', email: '', phone: '', calendarId: 'hank-calendar' }),
-        new Chef({ name: 'Mary', email: '', phone: '', calendarId: 'mary-calendar' }),
-      ];
+      const hank = new Chef({ name: 'Hank', email: '', phone: '', calendarId: 'hank-calendar' });
+      const mary = new Chef({ name: 'Mary', email: '', phone: '', calendarId: 'mary-calendar' });
 
-      const chefsAvailabilitySpies = chefs.map(chef => jest.spyOn(chef, 'setAvailabilityNextWeek'));
+      const spySetAvailabilityNextWeekHank = jest.spyOn(hank, 'setAvailabilityNextWeek');
+      const spySetAvailabilityNextWeekMary = jest.spyOn(mary, 'setAvailabilityNextWeek');
 
       beforeEach(async () => {
-        await GoogleCalendarService.queryAndSetChefsAvailabilityNextWeek(chefs);
+        await GoogleCalendarService.queryAndSetChefsAvailabilityNextWeek([hank, mary]);
       });
 
       it('calls on GCal freebusy query only once', () => {
@@ -156,10 +150,10 @@ describe('service: GoogleCalendarService', () => {
       });
 
       it('sets availability of each chef', () => {
-        chefsAvailabilitySpies.forEach(spy => {
-          expect(spy).toHaveBeenCalledTimes(1);
-          expect(spy).toHaveBeenCalledWith([]);
-        });
+        expect(spySetAvailabilityNextWeekHank).toHaveBeenCalledTimes(1);
+        expect(spySetAvailabilityNextWeekHank).toHaveBeenCalledWith([]);
+        expect(spySetAvailabilityNextWeekMary).toHaveBeenCalledTimes(1);
+        expect(spySetAvailabilityNextWeekMary).toHaveBeenCalledWith(undefined);
       });
     });
   });

--- a/src/services/google-calendar.ts
+++ b/src/services/google-calendar.ts
@@ -3,6 +3,11 @@ import { google } from 'googleapis';
 import moment from 'moment';
 import { Chef, Event } from '@/models';
 
+interface WriteAccessArg {
+  calendarId: string;
+  email: string;
+}
+
 /** Interface for Google's Calendar API */
 export default class GoogleCalendarService {
   /** APIs for Google Calendar */
@@ -18,6 +23,21 @@ export default class GoogleCalendarService {
   private static getJWT() {
     // TODO reuse token and refresh only as needed
     return this.googleAuthInstance.getClient() as Promise<JWT>;
+  }
+
+  /**
+   * Add a "writer" access control rule to the Google Calendar specified by passed-in
+   * calendarId, for user with passed-in email
+   *
+   * @param {WriteAccessArg} user object containing `calendarId` and user's `email`
+   */
+  static async addWriteAccessUserToCalendar({ calendarId, email }: WriteAccessArg) {
+    const auth = await this.getJWT();
+    await this.chefSchedule.acl.insert({
+      auth,
+      calendarId,
+      requestBody: { role: 'writer', scope: { type: 'user', value: email } },
+    });
   }
 
   /**


### PR DESCRIPTION
Use `node-cron` to run a task each Friday in `production` environments. Within the task,
generate a schedule, add the schedule's events to Google Calendar, and send an SMS to each
chef considered.

Additionally improve test coverage, fix the computation of a chef's availability score,
and add a method to the Google Calendar service for adding a write-access user to a
calendar.