### PR TITLE
Refactor cron job task into its own file

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,8 +1,9 @@
 import express from 'express';
 import { schedule as createTask } from 'node-cron';
-import { Person, ScheduleRequestBody } from '@/interfaces';
+import { ScheduleRequestBody } from '@/interfaces';
 import { ChefSchedule } from '@/models';
-import { GoogleCalendarService, TwilioService } from '@/services';
+import { GoogleCalendarService } from '@/services';
+import { main } from '@/tasks';
 
 const app = express();
 
@@ -22,19 +23,9 @@ app.post('/schedule', async ({ body }, res) => {
   }
 });
 
+/* istanbul ignore next */
 if (process.env.NODE_ENV === 'production') {
-  createTask('* * * * Friday', async () => {
-    try {
-      const people = JSON.parse(process.env.PEOPLE) as Person[];
-      const { events } = await ChefSchedule.generate();
-      await GoogleCalendarService.addEvents(events);
-      await TwilioService.sendGroupSMS({
-        body:
-          'A new Chef Schedule is available! Visit https://bit.ly/37bMa48 to see if/when you cook next week.',
-        toGroup: people.map(person => person.phone),
-      });
-    } catch (error) {}
-  });
+  createTask('* * * * Friday', main);
 }
 
 export default app;

--- a/src/models/__tests__/chef-schedule.test.ts
+++ b/src/models/__tests__/chef-schedule.test.ts
@@ -10,7 +10,7 @@ const spyQueryAndSetChefsAvailabilityNextWeek = jest
   .mockImplementation(async (chefs: Chef[]) => {
     chefs.forEach((chef, i) => {
       Object.keys(chef.availabilityNextWeek).forEach(day => {
-        // eslint-disable-next-line no-param-reassign
+        /* eslint-disable-next-line no-param-reassign */
         chef.availabilityNextWeek[day] = +day === i + 7;
       });
     });

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,8 +1,12 @@
+/* istanbul ignore file */
 import 'module-alias/register';
 import app from '@/app';
 
 const port = process.env.PORT || '4003';
-// eslint-disable-next-line no-console
-const server = app.listen(port, () => console.log(`listening on ${port}`));
+const server = app.listen(port, () => {
+  if (process.env.NODE_ENV !== 'test')
+    /* eslint-disable-next-line no-console */
+    console.log(`listening on ${port}`);
+});
 
 export default server;

--- a/src/tasks/__tests__/main.test.ts
+++ b/src/tasks/__tests__/main.test.ts
@@ -1,0 +1,58 @@
+import { Person } from '@/interfaces';
+import { ChefSchedule } from '@/models';
+import { GoogleCalendarService, TwilioService } from '@/services';
+import * as Tasks from '..';
+
+const { main } = Tasks;
+const spyMain = jest.spyOn(Tasks, 'main');
+
+const mockChefSchedule = { events: [] };
+
+const spyChefScheduleGenerate = jest
+  .spyOn(ChefSchedule, 'generate')
+  .mockResolvedValue(mockChefSchedule);
+
+const spyGoogleCalendarServiceAddEvents = jest
+  .spyOn(GoogleCalendarService, 'addEvents')
+  .mockResolvedValue();
+
+const spyTwilioServiceSendGroupSMS = jest
+  .spyOn(TwilioService, 'sendGroupSMS')
+  .mockResolvedValue([]);
+
+const people: Person[] = [{ name: 'Mary', email: '', phone: '15554201337', calendarId: '' }];
+
+describe('task: main', () => {
+  let PEOPLE: string;
+
+  beforeAll(() => {
+    PEOPLE = process.env.PEOPLE;
+    process.env.PEOPLE = JSON.stringify(people);
+  });
+
+  afterAll(() => {
+    process.env.PEOPLE = PEOPLE;
+  });
+
+  beforeEach(async () => {
+    await main();
+  });
+
+  it('generates a ChefSchedule', () => {
+    expect(spyChefScheduleGenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it('adds outputted events to Google Calendar', () => {
+    expect(spyGoogleCalendarServiceAddEvents).toHaveBeenCalledTimes(1);
+    expect(spyGoogleCalendarServiceAddEvents).toHaveBeenCalledWith(mockChefSchedule.events);
+  });
+
+  it('sends an SMS to the group indicating schedule is ready', () => {
+    expect(spyTwilioServiceSendGroupSMS).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw errors from any of the services', () => {
+    spyChefScheduleGenerate.mockRejectedValueOnce(new Error('my error'));
+    expect(spyMain).not.toThrow();
+  });
+});

--- a/src/tasks/__tests__/main.test.ts
+++ b/src/tasks/__tests__/main.test.ts
@@ -20,7 +20,10 @@ const spyTwilioServiceSendGroupSMS = jest
   .spyOn(TwilioService, 'sendGroupSMS')
   .mockResolvedValue([]);
 
-const people: Person[] = [{ name: 'Mary', email: '', phone: '15554201337', calendarId: '' }];
+const people: Person[] = [
+  { name: 'Mary', email: '', phone: '15554201337', calendarId: '' },
+  { name: 'Hank', email: '', phone: '15554206969', calendarId: '' },
+];
 
 describe('task: main', () => {
   let PEOPLE: string;
@@ -49,6 +52,9 @@ describe('task: main', () => {
 
   it('sends an SMS to the group indicating schedule is ready', () => {
     expect(spyTwilioServiceSendGroupSMS).toHaveBeenCalledTimes(1);
+    people.forEach(person => {
+      expect(spyTwilioServiceSendGroupSMS.mock.calls[0][0].toGroup).toContain(person.phone);
+    });
   });
 
   it('does not throw errors from any of the services', () => {

--- a/src/tasks/__tests__/main.test.ts
+++ b/src/tasks/__tests__/main.test.ts
@@ -3,6 +3,8 @@ import { ChefSchedule } from '@/models';
 import { GoogleCalendarService, TwilioService } from '@/services';
 import * as Tasks from '..';
 
+jest.mock('twilio');
+
 const { main } = Tasks;
 const spyMain = jest.spyOn(Tasks, 'main');
 

--- a/src/tasks/__tests__/tsconfig.json
+++ b/src/tasks/__tests__/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["../../../node_modules"]
+}

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -1,0 +1,1 @@
+export { default as main } from './main';

--- a/src/tasks/main.ts
+++ b/src/tasks/main.ts
@@ -1,0 +1,16 @@
+import { Person } from '@/interfaces';
+import { ChefSchedule } from '@/models';
+import { GoogleCalendarService, TwilioService } from '@/services';
+
+export default async () => {
+  try {
+    const people = JSON.parse(process.env.PEOPLE) as Person[];
+    const { events } = await ChefSchedule.generate();
+    await GoogleCalendarService.addEvents(events);
+    await TwilioService.sendGroupSMS({
+      body:
+        'A new Chef Schedule is available! Visit https://bit.ly/37bMa48 to see if/when you cook next week.',
+      toGroup: people.map(person => person.phone),
+    });
+  } catch (error) {}
+};


### PR DESCRIPTION
Move the task scheduled by `node-cron` into its own file to improve
testability and test coverage. Ignore `src/server.ts` from test coverage
due to its content being irrelevant for test coverage.